### PR TITLE
Catchup mode: read pages of blocks, when we're a long way behind

### DIFF
--- a/internal/events/eventstream_test.go
+++ b/internal/events/eventstream_test.go
@@ -484,6 +484,83 @@ func setupTestSubscription(assert *assert.Assertions, sm *subscriptionMGR, strea
 	return s
 }
 
+func setupCatchupTestSubscription(assert *assert.Assertions, sm *subscriptionMGR, stream *eventStream, subscriptionName string) *SubscriptionInfo {
+	log.SetLevel(log.DebugLevel)
+	testDataBytes, err := ioutil.ReadFile("../../test/simplevents_logs.json")
+	assert.NoError(err)
+	var testData []*logEntry
+	json.Unmarshal(testDataBytes, &testData)
+	testBlockDetailBytes, err := ioutil.ReadFile("../../test/block_details.json")
+	assert.NoError(err)
+	testBlock := &ethbinding.Header{}
+	var parsedBlock map[string]interface{}
+	json.Unmarshal(testBlockDetailBytes, &parsedBlock)
+	ts := parsedBlock["timestamp"].(float64)
+	testBlock.Time = uint64(ts)
+
+	callCount := 0
+	getLogsCalls := 0
+	rpc := eth.NewMockRPCClientForSync(nil, func(method string, res interface{}, args ...interface{}) {
+		callCount++
+		log.Infof("UT %s call=%d", method, callCount)
+		if method == "eth_blockNumber" {
+			(*(res.(*ethbinding.HexBigInt))).ToInt().SetString("501", 10)
+		} else if method == "eth_getLogs" {
+			if getLogsCalls == 0 {
+				// Catchup page with data
+				*(res.(*[]*logEntry)) = testData[0:2]
+			} else {
+				// Catchup page with no data
+				*(res.(*[]*logEntry)) = []*logEntry{}
+			}
+			getLogsCalls++
+			assert.LessOrEqual(getLogsCalls, 2)
+		} else if method == "eth_getFilterLogs" {
+			// First page after catchup
+			*(res.(*[]*logEntry)) = testData[2:]
+		} else if method == "eth_getFilterChanges" {
+			// No further updates
+			*(res.(*[]*logEntry)) = []*logEntry{}
+		} else if method == "eth_getBlockByNumber" {
+			*(res.(*ethbinding.Header)) = *testBlock
+		}
+	})
+	sm.rpc = rpc
+
+	event := &ethbinding.ABIElementMarshaling{
+		Name: "Changed",
+		Inputs: []ethbinding.ABIArgumentMarshaling{
+			{
+				Name:    "from",
+				Type:    "address",
+				Indexed: true,
+			},
+			{
+				Name:    "i",
+				Type:    "int64",
+				Indexed: true,
+			},
+			{
+				Name:    "s",
+				Type:    "string",
+				Indexed: true,
+			},
+			{
+				Name: "h",
+				Type: "bytes32",
+			},
+			{
+				Name: "m",
+				Type: "string",
+			},
+		},
+	}
+	addr := ethbind.API.HexToAddress("0x167f57a13a9c35ff92f0649d2be0e52b4f8ac3ca")
+	ctx := context.Background()
+	s, _ := sm.AddSubscription(ctx, &addr, event, stream.spec.ID, "0", subscriptionName)
+	return s
+}
+
 func TestProcessEventsEnd2EndWebhook(t *testing.T) {
 	assert := assert.New(t)
 	dir := tempdir(t)
@@ -499,6 +576,55 @@ func TestProcessEventsEnd2EndWebhook(t *testing.T) {
 	defer svr.Close()
 
 	s := setupTestSubscription(assert, sm, stream, "mySubName")
+	assert.Equal("mySubName", s.Name)
+
+	// We expect three events to be sent to the webhook
+	// With the default batch size of 1, that means three separate requests
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		e1s := <-eventStream
+		assert.Equal(1, len(e1s))
+		assert.Equal("42", e1s[0].Data["i"])
+		assert.Equal("But what is the question?", e1s[0].Data["m"])
+		assert.Equal("150665", e1s[0].BlockNumber)
+		e2s := <-eventStream
+		assert.Equal(1, len(e2s))
+		assert.Equal("1977", e2s[0].Data["i"])
+		assert.Equal("A long time ago in a galaxy far, far away....", e2s[0].Data["m"])
+		assert.Equal("150665", e2s[0].BlockNumber)
+		e3s := <-eventStream
+		assert.Equal(1, len(e3s))
+		assert.Equal("20151021", e3s[0].Data["i"])
+		assert.Equal("1.21 Gigawatts!", e3s[0].Data["m"])
+		assert.Equal("150721", e3s[0].BlockNumber)
+		wg.Done()
+	}()
+	wg.Wait()
+
+	ctx := context.Background()
+	err := sm.DeleteSubscription(ctx, s.ID)
+	assert.NoError(err)
+	err = sm.DeleteStream(ctx, stream.spec.ID)
+	assert.NoError(err)
+	sm.Close()
+}
+
+func TestProcessEventsEnd2EndCatchupWebhook(t *testing.T) {
+	assert := assert.New(t)
+	dir := tempdir(t)
+	defer cleanup(t, dir)
+
+	db, _ := kvstore.NewLDBKeyValueStore(dir)
+	sm, stream, svr, eventStream := newTestStreamForBatching(
+		&StreamInfo{
+			BatchSize:  1,
+			Webhook:    &webhookActionInfo{},
+			Timestamps: false,
+		}, db, 200)
+	defer svr.Close()
+
+	s := setupCatchupTestSubscription(assert, sm, stream, "mySubName")
 	assert.Equal("mySubName", s.Name)
 
 	// We expect three events to be sent to the webhook

--- a/internal/events/submanager.go
+++ b/internal/events/submanager.go
@@ -42,6 +42,9 @@ const (
 	subIDPrefix        = "sb-"
 	streamIDPrefix     = "es-"
 	checkpointIDPrefix = "cp-"
+
+	defaultCatchupModeBlockGap = int64(250)
+	defaultCatchupModePageSize = int64(250)
 )
 
 // SubscriptionManager provides REST APIs for managing events
@@ -75,6 +78,8 @@ type subscriptionManager interface {
 type SubscriptionManagerConf struct {
 	EventLevelDBPath        string `json:"eventsDB"`
 	EventPollingIntervalSec uint64 `json:"eventPollingIntervalSec,omitempty"`
+	CatchupModeBlockGap     int64  `json:"catchupModeBlockGap,omitempty"`
+	CatchupModePageSize     int64  `json:"catchupModePageSize,omitempty"`
 	WebhooksAllowPrivateIPs bool   `json:"webhooksAllowPrivateIPs,omitempty"`
 }
 
@@ -107,6 +112,12 @@ func NewSubscriptionManager(conf *SubscriptionManagerConf, rpc eth.RPCClient, ws
 	}
 	if conf.EventPollingIntervalSec <= 0 {
 		conf.EventPollingIntervalSec = 1
+	}
+	if conf.CatchupModeBlockGap <= 0 {
+		conf.CatchupModeBlockGap = defaultCatchupModeBlockGap
+	}
+	if conf.CatchupModePageSize <= 0 {
+		conf.CatchupModePageSize = defaultCatchupModePageSize
 	}
 	return sm
 }

--- a/internal/events/submanager_test.go
+++ b/internal/events/submanager_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path"
-	"reflect"
 	"testing"
 	"time"
 
@@ -34,26 +33,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type mockRPC struct {
-	capturedMethod string
-	mockError      error
-	result         interface{}
-}
-
-func (m *mockRPC) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
-	m.capturedMethod = method
-	v := reflect.ValueOf(result)
-	v.Elem().Set(reflect.ValueOf(m.result))
-	return m.mockError
-}
-
 type mockWebSocket struct {
-	registeredNamespace string
-	capturedNamespace   string
-	sender              chan interface{}
-	broadcast           chan interface{}
-	receiver            chan error
-	closing             chan struct{}
+	capturedNamespace string
+	sender            chan interface{}
+	broadcast         chan interface{}
+	receiver          chan error
+	closing           chan struct{}
 }
 
 func (m *mockWebSocket) GetChannels(namespace string) (chan<- interface{}, chan<- interface{}, <-chan error, <-chan struct{}) {

--- a/internal/events/subscription.go
+++ b/internal/events/subscription.go
@@ -86,7 +86,7 @@ func newSubscription(sm subscriptionManager, rpc eth.RPCClient, addr *ethbinding
 		logName:             i.ID + ":" + ethbind.API.ABIEventSignature(event),
 		filterStale:         true,
 		catchupModeBlockGap: sm.config().CatchupModeBlockGap,
-		catchupModePageSize: sm.config().CatchupModeBlockGap,
+		catchupModePageSize: sm.config().CatchupModePageSize,
 	}
 	f := &i.Filter
 	addrStr := "*"

--- a/internal/events/subscription.go
+++ b/internal/events/subscription.go
@@ -191,13 +191,13 @@ func (s *subscription) restartFilter(ctx context.Context, checkpoint *big.Int) e
 		since = s.catchupBlock
 	}
 
-	var blockNumber big.Int
+	blockNumber := ethbinding.HexBigInt{}
 	err := s.rpc.CallContext(ctx, &blockNumber, "eth_blockNumber")
 	if err != nil {
 		return errors.Errorf(errors.RPCCallReturnedError, "eth_blockNumber", err)
 	}
 
-	blockGap := new(big.Int).Sub(&blockNumber, since).Int64()
+	blockGap := new(big.Int).Sub(blockNumber.ToInt(), since).Int64()
 	if s.catchupModeBlockGap > 0 && blockGap > s.catchupModeBlockGap {
 		s.catchupBlock = since // note if we were already in catchup, this does not change anything
 		return nil
@@ -247,7 +247,7 @@ func (s *subscription) processCatchupBlocks(ctx context.Context) error {
 
 	log.Infof("%s: catchup mode. Blocks %d -> %d", s.logName, s.catchupBlock.Int64(), endBlock.Int64())
 	if err := s.rpc.CallContext(ctx, &logs, "eth_getLogs", f); err != nil {
-		return err
+		return errors.Errorf(errors.RPCCallReturnedError, "eth_getLogs", err)
 	}
 	if len(logs) == 0 {
 		// We only want to catch up once - so see if we can update our HWM based on the fact

--- a/internal/events/subscription_test.go
+++ b/internal/events/subscription_test.go
@@ -246,6 +246,16 @@ func TestRestartFilterFail(t *testing.T) {
 		rpc:  eth.NewMockRPCClientForSync(fmt.Errorf("pop"), nil),
 	}
 	err := s.restartFilter(context.Background(), big.NewInt(0))
+	assert.EqualError(err, "eth_blockNumber returned: pop")
+}
+
+func TestCreateFilterFail(t *testing.T) {
+	assert := assert.New(t)
+	s := &subscription{
+		info: &SubscriptionInfo{},
+		rpc:  eth.NewMockRPCClientForSync(fmt.Errorf("pop"), nil),
+	}
+	err := s.createFilter(context.Background(), big.NewInt(0))
 	assert.EqualError(err, "eth_newFilter returned: pop")
 }
 

--- a/internal/events/subscription_test.go
+++ b/internal/events/subscription_test.go
@@ -259,6 +259,17 @@ func TestCreateFilterFail(t *testing.T) {
 	assert.EqualError(err, "eth_newFilter returned: pop")
 }
 
+func TestProcessCatchupBlocksFail(t *testing.T) {
+	assert := assert.New(t)
+	s := &subscription{
+		info:         &SubscriptionInfo{},
+		rpc:          eth.NewMockRPCClientForSync(fmt.Errorf("pop"), nil),
+		catchupBlock: big.NewInt(12345),
+	}
+	err := s.processCatchupBlocks(context.Background())
+	assert.EqualError(err, "eth_getLogs returned: pop")
+}
+
 func TestEventTimestampFail(t *testing.T) {
 	assert := assert.New(t)
 	stream := newTestStream()


### PR DESCRIPTION
The ethereum log streaming interface, doesn't have any ability to limit/paginate calls to `eth_getFilterLogs` / `eth_getFilterChanges`, per https://github.com/ethereum/go-ethereum/issues/17487

This is problematic on chains with large numbers of blocks & transactions, when trying to reply events from a long way behind the current block.

Currently the code performs an `eth_getFilterLogs` from the latest checkpoint -> `latest`, which could be millions of blocks in the case of a new node joining the network.

So this PR proposes adding an automatically enabled "catchup" mode, in the case that a stream is restarting and finds itself a long way behind in the latest block on the node it's on. 
In this mode we repeat the following to read pages of blocks:
1. `eth_blockNumber`
2. `eth_getLogs` - checkpoint (or last page end), to end of page
... that happens until we find we're get within that window of the head again.

Default is to enable it when we are restarting `250` blocks or more behind the head, and read `250` blocks at a time.

There are some unrelated lint fixes in this PR too that were picked up by my compiler.