### PR TITLE
Handle spurious acks

### DIFF
--- a/internal/ws/wsconn.go
+++ b/internal/ws/wsconn.go
@@ -163,7 +163,7 @@ func (c *webSocketConnection) handleAckOrError(t *webSocketTopic, err error) {
 		log.Debugf("WS/%s: response (error='%t') on topic '%s' passed on for processing", c.id, isError, t.topic)
 		break
 	default:
-		log.Debugf("WS/%s: suprious ack received (error='%t') on topic '%s'", c.id, isError, t.topic)
+		log.Debugf("WS/%s: spurious ack received (error='%t') on topic '%s'", c.id, isError, t.topic)
 		break
 	}
 }

--- a/internal/ws/wsconn.go
+++ b/internal/ws/wsconn.go
@@ -18,7 +18,6 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"time"
 
 	ws "github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
@@ -160,11 +159,11 @@ func (c *webSocketConnection) listen() {
 func (c *webSocketConnection) handleAckOrError(t *webSocketTopic, err error) {
 	isError := err != nil
 	select {
-	case <-time.After(c.server.processingTimeout):
-		log.Errorf("WS/%s: response (error='%t') on topic '%s'. We were not available to process it after %.2f seconds. Closing connection", c.id, isError, t.topic, c.server.processingTimeout.Seconds())
-		c.close()
 	case t.receiverChannel <- err:
 		log.Debugf("WS/%s: response (error='%t') on topic '%s' passed on for processing", c.id, isError, t.topic)
+		break
+	default:
+		log.Debugf("WS/%s: suprious ack received (error='%t') on topic '%s'", c.id, isError, t.topic)
 		break
 	}
 }

--- a/internal/ws/wsserver.go
+++ b/internal/ws/wsserver.go
@@ -130,7 +130,7 @@ func (s *webSocketServer) getTopic(topic string) *webSocketTopic {
 			topic:            topic,
 			senderChannel:    make(chan interface{}),
 			broadcastChannel: make(chan interface{}),
-			receiverChannel:  make(chan error),
+			receiverChannel:  make(chan error, 1),
 			closingChannel:   make(chan struct{}),
 		}
 		s.topics[topic] = t

--- a/internal/ws/wsserver_test.go
+++ b/internal/ws/wsserver_test.go
@@ -178,7 +178,7 @@ func TestConnectAbandonRequest(t *testing.T) {
 
 }
 
-func TestTimeoutProcessing(t *testing.T) {
+func TestSpuriousAckProcessing(t *testing.T) {
 	assert := assert.New(t)
 
 	w, ts := newTestWebSocketServer()
@@ -192,16 +192,27 @@ func TestTimeoutProcessing(t *testing.T) {
 	assert.NoError(err)
 
 	c.WriteJSON(&webSocketCommandMessage{
-		Type: "ack",
+		Type:  "ack",
+		Topic: "mytopic",
 	})
+	c.WriteJSON(&webSocketCommandMessage{
+		Type:  "ack",
+		Topic: "mytopic",
+	})
+	c.Close()
 
-	// Confirm we close the connection after the timeout pops
 	for len(w.connections) > 0 {
 		time.Sleep(1 * time.Millisecond)
 	}
 
+	for _, conn := range w.connections {
+		_, _, receiver, _ := conn.server.GetChannels("mytopic")
+		select {
+		case <-receiver:
+			return
+		}
+	}
 	w.Close()
-
 }
 
 func TestConnectBadWebsocketHandshake(t *testing.T) {

--- a/internal/ws/wsserver_test.go
+++ b/internal/ws/wsserver_test.go
@@ -204,14 +204,6 @@ func TestSpuriousAckProcessing(t *testing.T) {
 	for len(w.connections) > 0 {
 		time.Sleep(1 * time.Millisecond)
 	}
-
-	for _, conn := range w.connections {
-		_, _, receiver, _ := conn.server.GetChannels("mytopic")
-		select {
-		case <-receiver:
-			return
-		}
-	}
 	w.Close()
 }
 


### PR DESCRIPTION
Currently there are two cases where the ack processing can get stuck:
- An application sends a spurious additional ack
  - The WS code tries to deliver this to the eventstream code, while the ES code is trying to wait for a message
  - Eventually results in `We were not available to process it after ... seconds` in the logs
- The ES code receives an update to the eventstream, while it's waiting for an ack
  - This results in the WS code never being able to deliver the ack, so never delivering the next message

The proposed change in this PR adds a buffer of 1 to the channel between the WS and ES code, and changes the timeout into a `default` when delivering the ack. This prevents the deadlock possibility. There are always either `0` or `1` acks in the pipe.