### PR TITLE
Add fly-transaction param to query transaction details

### DIFF
--- a/internal/contractgateway/rest2eth_test.go
+++ b/internal/contractgateway/rest2eth_test.go
@@ -1629,8 +1629,6 @@ func TestSendTransactionWithIDAsyncSuccess(t *testing.T) {
 		},
 	}
 	_, _, router, res, req := newTestREST2EthAndMsg(t, dispatcher, from, to, bodyMap)
-	req.Header.Set("X-Firefly-PrivateFrom", "0xdC416B907857Fa8c0e0d55ec21766Ee3546D5f90")
-	req.Header.Set("X-Firefly-PrivateFor", "0xE7E32f0d5A2D55B2aD27E0C2d663807F28f7c745,0xB92F8CebA52fFb5F08f870bd355B1d32f0fd9f7C")
 	req.Header.Set("X-Firefly-ID", "my-id")
 	router.ServeHTTP(res, req)
 
@@ -1644,8 +1642,56 @@ func TestSendTransactionWithIDAsyncSuccess(t *testing.T) {
 	assert.Equal(true, dispatcher.asyncDispatchAck)
 	assert.Equal(from, dispatcher.asyncDispatchMsg["from"])
 	assert.Equal(to, dispatcher.asyncDispatchMsg["to"])
-	assert.Equal("0xdC416B907857Fa8c0e0d55ec21766Ee3546D5f90", dispatcher.asyncDispatchMsg["privateFrom"])
-	assert.Equal("0xE7E32f0d5A2D55B2aD27E0C2d663807F28f7c745", dispatcher.asyncDispatchMsg["privateFor"].([]interface{})[0])
-	assert.Equal("0xB92F8CebA52fFb5F08f870bd355B1d32f0fd9f7C", dispatcher.asyncDispatchMsg["privateFor"].([]interface{})[1])
 	assert.Equal("my-id", dispatcher.asyncDispatchMsg["headers"].(map[string]interface{})["id"])
+}
+
+func TestGetTransactionInfoSuccess(t *testing.T) {
+	assert := assert.New(t)
+	dir := tempdir()
+	defer cleanup(dir)
+
+	dispatcher := &mockREST2EthDispatcher{}
+	_, rpc, router, res, req := newTestREST2EthAndMsg(t, dispatcher, "", "", nil)
+	rpc.result = eth.TxnInfo{Input: &ethbinding.HexBytes{
+		0x09, 0x23, 0xf7, 0x0f,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	}}
+	req.Header.Set("X-Firefly-Transaction", "0x9999")
+	router.ServeHTTP(res, req)
+
+	assert.Equal(200, res.Result().StatusCode)
+	var resultBody map[string]interface{}
+	err := json.NewDecoder(res.Result().Body).Decode(&resultBody)
+	assert.NoError(err)
+	assert.Equal(map[string]interface{}{"i": "0", "s": ""}, resultBody["inputArgs"])
+}
+
+func TestGetTransactionInfoFail(t *testing.T) {
+	assert := assert.New(t)
+	dir := tempdir()
+	defer cleanup(dir)
+
+	dispatcher := &mockREST2EthDispatcher{}
+	_, rpc, router, res, req := newTestREST2EthAndMsg(t, dispatcher, "", "", nil)
+	rpc.result = eth.TxnInfo{}
+	rpc.mockError = fmt.Errorf("pop")
+	req.Header.Set("X-Firefly-Transaction", "0x9999")
+	router.ServeHTTP(res, req)
+
+	assert.Equal(500, res.Result().StatusCode)
+}
+
+func TestGetTransactionInfoDecodeFail(t *testing.T) {
+	assert := assert.New(t)
+	dir := tempdir()
+	defer cleanup(dir)
+
+	dispatcher := &mockREST2EthDispatcher{}
+	_, rpc, router, res, req := newTestREST2EthAndMsg(t, dispatcher, "", "", nil)
+	rpc.result = eth.TxnInfo{Input: &ethbinding.HexBytes{}}
+	req.Header.Set("X-Firefly-Transaction", "0x9999")
+	router.ServeHTTP(res, req)
+
+	assert.Equal(500, res.Result().StatusCode)
 }

--- a/internal/contractgateway/rest2eth_test.go
+++ b/internal/contractgateway/rest2eth_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -1650,13 +1651,25 @@ func TestGetTransactionInfoSuccess(t *testing.T) {
 	dir := tempdir()
 	defer cleanup(dir)
 
+	gas := uint64(5000)
+	nonce := uint64(12)
+	txindex := uint64(0)
+
 	dispatcher := &mockREST2EthDispatcher{}
 	_, rpc, router, res, req := newTestREST2EthAndMsg(t, dispatcher, "", "", nil)
-	rpc.result = eth.TxnInfo{Input: &ethbinding.HexBytes{
-		0x09, 0x23, 0xf7, 0x0f,
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	}}
+	rpc.result = eth.TxnInfo{
+		BlockNumber:      (*ethbinding.HexBigInt)(big.NewInt(15)),
+		Gas:              (*ethbinding.HexUint64)(&gas),
+		GasPrice:         (*ethbinding.HexBigInt)(big.NewInt(0)),
+		Nonce:            (*ethbinding.HexUint64)(&nonce),
+		TransactionIndex: (*ethbinding.HexUint64)(&txindex),
+		Value:            (*ethbinding.HexBigInt)(big.NewInt(10)),
+		Input: &ethbinding.HexBytes{
+			0x09, 0x23, 0xf7, 0x0f,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		},
+	}
 	req.Header.Set("X-Firefly-Transaction", "0x9999")
 	router.ServeHTTP(res, req)
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -320,6 +320,11 @@ const (
 	// SecurityModuleNoAuthContext missing auth context in context object at point security module is invoked
 	SecurityModuleNoAuthContext = "No auth context"
 
+	// TransactionQueryFailed transaction lookup failed
+	TransactionQueryFailed = "Failed to query transaction"
+	// TransactionQueryMethodMismatch transaction input did not match the method queried
+	TransactionQueryMethodMismatch = "Method signature did not match: %s != %s"
+
 	// TransactionSendConstructorPackArgs RLP encoding failure for a constructor
 	TransactionSendConstructorPackArgs = "Packing arguments for constructor: %s"
 	// TransactionSendMethodPackArgs RLP encoding failure for a method

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -321,7 +321,7 @@ const (
 	SecurityModuleNoAuthContext = "No auth context"
 
 	// TransactionQueryFailed transaction lookup failed
-	TransactionQueryFailed = "Failed to query transaction"
+	TransactionQueryFailed = "Failed to query transaction: %s"
 	// TransactionQueryMethodMismatch transaction input did not match the method queried
 	TransactionQueryMethodMismatch = "Method signature did not match: %s != %s"
 

--- a/internal/eth/txn.go
+++ b/internal/eth/txn.go
@@ -69,11 +69,11 @@ type TxnInfo struct {
 	BlockNumber      *ethbinding.HexBigInt `json:"blockNumber,omitempty"`
 	From             *ethbinding.Address   `json:"from,omitempty"`
 	To               *ethbinding.Address   `json:"to,omitempty"`
-	Gas              *ethbinding.HexBigInt `json:"gas"`
+	Gas              *ethbinding.HexUint64 `json:"gas"`
 	GasPrice         *ethbinding.HexBigInt `json:"gasPrice"`
 	Hash             *ethbinding.Hash      `json:"hash"`
-	Nonce            *ethbinding.HexUint   `json:"nonce"`
-	TransactionIndex *ethbinding.HexUint   `json:"transactionIndex"`
+	Nonce            *ethbinding.HexUint64 `json:"nonce"`
+	TransactionIndex *ethbinding.HexUint64 `json:"transactionIndex"`
 	Value            *ethbinding.HexBigInt `json:"value"`
 	Input            *ethbinding.HexBytes  `json:"input"`
 }

--- a/internal/eth/txn.go
+++ b/internal/eth/txn.go
@@ -173,8 +173,11 @@ func CallMethod(ctx context.Context, rpc RPCClient, signer TXSigner, from, addr 
 // Decode the "input" bytes from a transaction, which are composed of a method ID + encoded arguments
 func DecodeInputs(method *ethbinding.ABIMethod, inputs *ethbinding.HexBytes) (map[string]interface{}, error) {
 	methodIDLen := len(method.ID)
-	inputMethod := hex.EncodeToString((*inputs)[:methodIDLen])
 	expectedMethod := hex.EncodeToString(method.ID)
+	if len(*inputs) < methodIDLen {
+		return nil, fmt.Errorf(errors.TransactionQueryMethodMismatch, "unknown", expectedMethod)
+	}
+	inputMethod := hex.EncodeToString((*inputs)[:methodIDLen])
 	if inputMethod != expectedMethod {
 		log.Infof("Method did not match: %s != %s", inputMethod, expectedMethod)
 		return nil, fmt.Errorf(errors.TransactionQueryMethodMismatch, inputMethod, expectedMethod)

--- a/internal/eth/txn.go
+++ b/internal/eth/txn.go
@@ -63,6 +63,21 @@ type TxnReceipt struct {
 	TransactionIndex  *ethbinding.HexUint   `json:"transactionIndex"`
 }
 
+// TxnInfo is the detailed transaction info returned by eth_getTransactionByXXXXX
+type TxnInfo struct {
+	BlockHash        *ethbinding.Hash      `json:"blockHash,omitempty"`
+	BlockNumber      *ethbinding.HexBigInt `json:"blockNumber,omitempty"`
+	From             *ethbinding.Address   `json:"from,omitempty"`
+	To               *ethbinding.Address   `json:"to,omitempty"`
+	Gas              *ethbinding.HexBigInt `json:"gas"`
+	GasPrice         *ethbinding.HexBigInt `json:"gasPrice"`
+	Hash             *ethbinding.Hash      `json:"hash"`
+	Nonce            *ethbinding.HexUint   `json:"nonce"`
+	TransactionIndex *ethbinding.HexUint   `json:"transactionIndex"`
+	Value            *ethbinding.HexBigInt `json:"value"`
+	Input            *ethbinding.HexBytes  `json:"input"`
+}
+
 // NewContractDeployTxn builds a new ethereum transaction from the supplied
 // SendTranasction message
 func NewContractDeployTxn(msg *messages.DeployContract, signer TXSigner) (tx *Txn, err error) {
@@ -153,6 +168,30 @@ func CallMethod(ctx context.Context, rpc RPCClient, signer TXSigner, from, addr 
 		return nil, err
 	}
 	return ProcessRLPBytes(methodABI.Outputs, retBytes), nil
+}
+
+// Decode the "input" bytes from a transaction, which are composed of a method ID + encoded arguments
+func DecodeInputs(method *ethbinding.ABIMethod, txn *TxnInfo) (map[string]interface{}, error) {
+	methodIDLen := len(method.ID)
+	inputMethod := hex.EncodeToString((*txn.Input)[:methodIDLen])
+	expectedMethod := hex.EncodeToString(method.ID)
+	if inputMethod != expectedMethod {
+		log.Infof("Method did not match: %s != %s", inputMethod, expectedMethod)
+		return nil, fmt.Errorf(errors.TransactionQueryMethodMismatch, inputMethod, expectedMethod)
+	}
+	return ProcessRLPBytes(method.Inputs, (*txn.Input)[methodIDLen:]), nil
+}
+
+func GetTransactionInfo(ctx context.Context, rpc RPCClient, txHash string) (*TxnInfo, error) {
+	log.Debugf("Retrieving transaction %s", txHash)
+	var txn TxnInfo
+	if err := rpc.CallContext(ctx, &txn, "eth_getTransactionByHash", txHash); err != nil {
+		return nil, fmt.Errorf(errors.RPCCallReturnedError, "eth_getTransactionByHash", err)
+	}
+	if txn.Input == nil {
+		return nil, fmt.Errorf(errors.TransactionQueryFailed)
+	}
+	return &txn, nil
 }
 
 func addErrorToRetval(retval map[string]interface{}, retBytes []byte, rawRetval interface{}, err error) {

--- a/internal/eth/txn.go
+++ b/internal/eth/txn.go
@@ -171,15 +171,15 @@ func CallMethod(ctx context.Context, rpc RPCClient, signer TXSigner, from, addr 
 }
 
 // Decode the "input" bytes from a transaction, which are composed of a method ID + encoded arguments
-func DecodeInputs(method *ethbinding.ABIMethod, txn *TxnInfo) (map[string]interface{}, error) {
+func DecodeInputs(method *ethbinding.ABIMethod, inputs *ethbinding.HexBytes) (map[string]interface{}, error) {
 	methodIDLen := len(method.ID)
-	inputMethod := hex.EncodeToString((*txn.Input)[:methodIDLen])
+	inputMethod := hex.EncodeToString((*inputs)[:methodIDLen])
 	expectedMethod := hex.EncodeToString(method.ID)
 	if inputMethod != expectedMethod {
 		log.Infof("Method did not match: %s != %s", inputMethod, expectedMethod)
 		return nil, fmt.Errorf(errors.TransactionQueryMethodMismatch, inputMethod, expectedMethod)
 	}
-	return ProcessRLPBytes(method.Inputs, (*txn.Input)[methodIDLen:]), nil
+	return ProcessRLPBytes(method.Inputs, (*inputs)[methodIDLen:]), nil
 }
 
 func GetTransactionInfo(ctx context.Context, rpc RPCClient, txHash string) (*TxnInfo, error) {
@@ -189,7 +189,7 @@ func GetTransactionInfo(ctx context.Context, rpc RPCClient, txHash string) (*Txn
 		return nil, fmt.Errorf(errors.RPCCallReturnedError, "eth_getTransactionByHash", err)
 	}
 	if txn.Input == nil {
-		return nil, fmt.Errorf(errors.TransactionQueryFailed)
+		return nil, fmt.Errorf(errors.TransactionQueryFailed, txHash)
 	}
 	return &txn, nil
 }

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -162,6 +162,30 @@ type TransactionReceipt struct {
 	RegisterAs           string                `json:"registerAs,omitempty"`
 }
 
+// TransactionInfo is the detailed transaction info returned by eth_getTransactionByXXXXX
+// For the big numbers, we pass a simple string as well as a full
+// ethereum hex encoding version
+type TransactionInfo struct {
+	BlockHash           *ethbinding.Hash       `json:"blockHash,omitempty"`
+	BlockNumberStr      string                 `json:"blockNumber,omitempty"`
+	BlockNumberHex      *ethbinding.HexBigInt  `json:"blockNumberHex,omitempty"`
+	From                *ethbinding.Address    `json:"from,omitempty"`
+	To                  *ethbinding.Address    `json:"to,omitempty"`
+	GasStr              string                 `json:"gas"`
+	GasHex              *ethbinding.HexUint64  `json:"gasHex"`
+	GasPriceStr         string                 `json:"gasPrice"`
+	GasPriceHex         *ethbinding.HexBigInt  `json:"gasPriceHex"`
+	Hash                *ethbinding.Hash       `json:"hash"`
+	NonceStr            string                 `json:"nonce"`
+	NonceHex            *ethbinding.HexUint64  `json:"nonceHex"`
+	TransactionIndexStr string                 `json:"transactionIndex"`
+	TransactionIndexHex *ethbinding.HexUint64  `json:"transactionIndexHex"`
+	ValueStr            string                 `json:"value"`
+	ValueHex            *ethbinding.HexBigInt  `json:"valueHex"`
+	Input               *ethbinding.HexBytes   `json:"input"`
+	InputArgs           map[string]interface{} `json:"inputArgs"`
+}
+
 // ErrorReply is
 type ErrorReply struct {
 	ReplyCommon

--- a/internal/openapi/abi2swagger.go
+++ b/internal/openapi/abi2swagger.go
@@ -395,6 +395,18 @@ func (c *ABI2Swagger) getCommonParameters() map[string]spec.Parameter {
 			Type: "string",
 		},
 	}
+	params["transactionParam"] = spec.Parameter{
+		ParamProps: spec.ParamProps{
+			Description:     fmt.Sprintf("Query the details for the provided transaction hash (header: x-%s-transaction)", utils.GetenvOrDefaultLowerCase("PREFIX_LONG", "firefly")),
+			Name:            fmt.Sprintf("%s-transaction", utils.GetenvOrDefaultLowerCase("PREFIX_SHORT", "fly")),
+			In:              "query",
+			Required:        false,
+			AllowEmptyValue: true,
+		},
+		SimpleSchema: spec.SimpleSchema{
+			Type: "string",
+		},
+	}
 	return params
 }
 
@@ -416,6 +428,7 @@ func (c *ABI2Swagger) addCommonParams(op *spec.Operation, isPOST bool, isConstru
 	privacyGroupIDParam, _ := spec.NewRef("#/parameters/privacyGroupIdParam")
 	registerParam, _ := spec.NewRef("#/parameters/registerParam")
 	blocknumberParam, _ := spec.NewRef("#/parameters/blocknumberParam")
+	transactionParam, _ := spec.NewRef("#/parameters/transactionParam")
 	op.Parameters = append(op.Parameters, spec.Parameter{
 		Refable: spec.Refable{
 			Ref: idParam,
@@ -474,6 +487,12 @@ func (c *ABI2Swagger) addCommonParams(op *spec.Operation, isPOST bool, isConstru
 				},
 			})
 		}
+	} else {
+		op.Parameters = append(op.Parameters, spec.Parameter{
+			Refable: spec.Refable{
+				Ref: transactionParam,
+			},
+		})
 	}
 	if isConstructor {
 		op.Parameters = append(op.Parameters, spec.Parameter{

--- a/test/abicoderv2_example.swagger.json
+++ b/test/abicoderv2_example.swagger.json
@@ -41,6 +41,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -222,6 +225,13 @@
       "default": true,
       "description": "Block the HTTP request until the tx is mined (does not store the receipt) (header: x-firefly-sync)",
       "name": "fly-sync",
+      "in": "query",
+      "allowEmptyValue": true
+    },
+    "transactionParam": {
+      "type": "string",
+      "description": "Query the details for the provided transaction hash (header: x-firefly-transaction)",
+      "name": "fly-transaction",
       "in": "query",
       "allowEmptyValue": true
     },

--- a/test/erc20.swagger.json
+++ b/test/erc20.swagger.json
@@ -384,6 +384,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -532,6 +535,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -673,6 +679,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -821,6 +830,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -969,6 +981,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -1103,6 +1118,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -1251,6 +1269,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -1406,6 +1427,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -1814,6 +1838,13 @@
       "default": true,
       "description": "Block the HTTP request until the tx is mined (does not store the receipt) (header: x-firefly-sync)",
       "name": "fly-sync",
+      "in": "query",
+      "allowEmptyValue": true
+    },
+    "transactionParam": {
+      "type": "string",
+      "description": "Query the details for the provided transaction hash (header: x-firefly-transaction)",
+      "name": "fly-transaction",
       "in": "query",
       "allowEmptyValue": true
     },

--- a/test/lotsoftypes.swagger.json
+++ b/test/lotsoftypes.swagger.json
@@ -89,6 +89,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -258,6 +261,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -419,6 +425,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -842,6 +851,13 @@
       "default": true,
       "description": "Block the HTTP request until the tx is mined (does not store the receipt) (header: x-firefly-sync)",
       "name": "fly-sync",
+      "in": "query",
+      "allowEmptyValue": true
+    },
+    "transactionParam": {
+      "type": "string",
+      "description": "Query the details for the provided transaction hash (header: x-firefly-transaction)",
+      "name": "fly-transaction",
       "in": "query",
       "allowEmptyValue": true
     },

--- a/test/unnamedinput.swagger.json
+++ b/test/unnamedinput.swagger.json
@@ -176,6 +176,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -315,6 +318,9 @@
           },
           {
             "$ref": "#/parameters/gaspriceParam"
+          },
+          {
+            "$ref": "#/parameters/transactionParam"
           }
         ],
         "responses": {
@@ -537,6 +543,13 @@
       "default": true,
       "description": "Block the HTTP request until the tx is mined (does not store the receipt) (header: x-firefly-sync)",
       "name": "fly-sync",
+      "in": "query",
+      "allowEmptyValue": true
+    },
+    "transactionParam": {
+      "type": "string",
+      "description": "Query the details for the provided transaction hash (header: x-firefly-transaction)",
+      "name": "fly-transaction",
       "in": "query",
       "allowEmptyValue": true
     },


### PR DESCRIPTION
Performing a GET to a method endpoint with fly-transaction set to a previously
executed transaction hash will return details on that transaction, including
the decoded input arguments.

~~I still need to add test coverage, but~~ I wanted to vet that this is a good design.
In particular want to see if we definitely want this on the method REST endpoint,
or if it should be at a higher level somehow.

~~Note that this branch also includes the enhancement from #140~~