### PR TITLE
Move contract sorting up to contractStore

### DIFF
--- a/internal/contractgateway/smartcontractgw.go
+++ b/internal/contractgateway/smartcontractgw.go
@@ -337,7 +337,7 @@ func (g *smartContractGW) writeAbiInfo(requestID string, msg *messages.DeployCon
 	return nil
 }
 
-// listContracts sorts by Title then Address and returns an array
+// listContractsOrABIs sorts by Title then Address and returns an array
 func (g *smartContractGW) listContractsOrABIs(res http.ResponseWriter, req *http.Request, params httprouter.Params) {
 	log.Infof("--> %s %s", req.Method, req.URL)
 
@@ -347,11 +347,6 @@ func (g *smartContractGW) listContractsOrABIs(res http.ResponseWriter, req *http
 	} else {
 		retval = g.cs.ListABIs()
 	}
-
-	// Do the sort by Title then Address
-	sort.Slice(retval, func(i, j int) bool {
-		return retval[i].IsLessThan(retval[i], retval[j])
-	})
 
 	status := 200
 	log.Infof("<-- %s %s [%d]", req.Method, req.URL, status)

--- a/internal/contractregistry/contractstore.go
+++ b/internal/contractregistry/contractstore.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -337,6 +338,11 @@ func (cs *contractStore) ListContracts() []messages.TimeSortable {
 		retval = append(retval, info)
 	}
 	cs.idxLock.Unlock()
+
+	// Do the sort by Title then Address
+	sort.Slice(retval, func(i, j int) bool {
+		return retval[i].IsLessThan(retval[i], retval[j])
+	})
 	return retval
 }
 
@@ -347,5 +353,10 @@ func (cs *contractStore) ListABIs() []messages.TimeSortable {
 		retval = append(retval, info)
 	}
 	cs.idxLock.Unlock()
+
+	// Do the sort by Title then Address
+	sort.Slice(retval, func(i, j int) bool {
+		return retval[i].IsLessThan(retval[i], retval[j])
+	})
 	return retval
 }


### PR DESCRIPTION
Makes the contractStore unit tests pass more reliably.